### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+os:
+  - linux
+  - osx
+language: generic
+sudo: required
+dist: trusty
+osx_image: xcode8.3
+script:
+  - eval "$(curl -sL https://swift.vapor.sh/ci-3.1)"
+  - eval "$(curl -sL https://swift.vapor.sh/codecov)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: generic
 sudo: required
 dist: trusty
 osx_image: xcode8.3
+services:
+  - redis-server
 script:
   - eval "$(curl -sL https://swift.vapor.sh/ci-3.1)"
   - eval "$(curl -sL https://swift.vapor.sh/codecov)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,17 @@ dist: trusty
 group: edge
 osx_image: xcode8.3
 
-services:
-    - redis-server
-
 before_install:
     - if [ $TRAVIS_OS_NAME == "osx" ]; then
             brew tap vapor/tap;
             brew update;
-            brew install vapor;
+            brew install vapor redis;
+            brew services start redis;
         else
             eval "$(curl -sL https://apt.vapor.sh)";
-            sudo apt-get install vapor;
+            sudo apt-get install vapor redis-server;
             sudo chmod -R a+rx /usr/;
+            sudo service redis-server start;
         fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
             eval "$(curl -sL https://apt.vapor.sh)";
             sudo apt-get install vapor redis-server;
             sudo chmod -R a+rx /usr/;
-            sudo service redis-server start;
         fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: generic
 sudo: required
 
 dist: trusty
+group: edge
 osx_image: xcode8.3
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,30 @@
 os:
-  - linux
-  - osx
+    - linux
+    - osx
 language: generic
 sudo: required
+
 dist: trusty
 osx_image: xcode8.3
+
 services:
-  - redis-server
+    - redis-server
+
+before_install:
+    - if [ $TRAVIS_OS_NAME == "osx" ]; then
+            brew tap vapor/tap;
+            brew update;
+            brew install vapor;
+        else
+            eval "$(curl -sL https://apt.vapor.sh)";
+            sudo apt-get install vapor;
+            sudo chmod -R a+rx /usr/;
+        fi
+
 script:
-  - eval "$(curl -sL https://swift.vapor.sh/ci-3.1)"
-  - eval "$(curl -sL https://swift.vapor.sh/codecov)"
+    - swift build
+    - swift build -c release
+    - swift test
+
+after_success:
+    - eval "$(curl -sL https://swift.vapor.sh/codecov)"


### PR DESCRIPTION
This PR fixes Travis CI with a script that:
- installs Swift 3.1 on Linux,
- installs Vapor 2.0 dependencies on both operating systems
- installs and starts a Redis server for the integration tests
- runs codecov in the end.

The script is based on the current script of the vapor/engine repo.