### PR TITLE
Add support for configuring Redis with URL for Vapor 1.x

### DIFF
--- a/Sources/VaporRedis/Provider.swift
+++ b/Sources/VaporRedis/Provider.swift
@@ -1,6 +1,7 @@
 import Vapor
 import Redbird
 import Foundation
+import URI
 
 /**
     Provides a RedisCache object to Vapor
@@ -33,6 +34,11 @@ public final class Provider: Vapor.Provider {
             throw Error.invalidRedisConfig("No redis.json file.")
         }
 
+        if let urlString = redis["url"]?.string {
+            try self.init(url: urlString)
+            return
+        }
+
         guard let address = redis["address"]?.string else {
             throw Error.invalidRedisConfig("No address.")
         }
@@ -44,6 +50,11 @@ public final class Provider: Vapor.Provider {
         let password = redis["password"]?.string
 
         try self.init(address: address, port: port, password: password)
+    }
+
+    public convenience init(url: String) throws {
+        let uri = try URIParser.parse(bytes: url.bytes)
+        try self.init(address: uri.host, port: uri.port ?? 6379, password: uri.userInfo?.info)
     }
 
     public func boot(_ droplet: Droplet) {

--- a/Tests/VaporRedisTests/ProviderTests.swift
+++ b/Tests/VaporRedisTests/ProviderTests.swift
@@ -6,6 +6,9 @@ class ProviderTests: XCTestCase {
     static let allTests = [
         ("testBasic", testBasic),
         ("testConfig", testConfig),
+        ("testUrl", testUrl),
+        ("testUrlWithDefaultPort", testUrlWithDefaultPort),
+        ("testConfigUrl", testConfigUrl)
     ]
 
     func testBasic() throws {
@@ -16,6 +19,22 @@ class ProviderTests: XCTestCase {
     func testConfig() throws {
         let drop = Droplet()
         let provider = try VaporRedis.Provider(config: drop.config)
+        XCTAssert(provider.provided.cache is RedisCache)
+    }
+
+    func testUrl() throws {
+        let provider = try VaporRedis.Provider(url: "redis://ignored@localhost:6379/ignored")
+        XCTAssert(provider.provided.cache is RedisCache)
+    }
+
+    func testUrlWithDefaultPort() throws {
+        let provider = try VaporRedis.Provider(url: "redis://ignored@localhost/ignored")
+        XCTAssert(provider.provided.cache is RedisCache)
+    }
+    
+    func testConfigUrl() throws {
+        let config = Config(["redis": ["url": "redis://ignored@localhost:6379/ignored"]])
+        let provider = try VaporRedis.Provider(config: config)
         XCTAssert(provider.provided.cache is RedisCache)
     }
 }


### PR DESCRIPTION
This is a reimplementation of @mcdappdev's URL support for v1. Cherry picking was not possible with all the renames and refactoring going on, so I just patched it in manually.

Resolves #20.