### PR TITLE
Fixed build error of `ambiguous init of Client`

### DIFF
--- a/Sources/RedisProvider/RedisCache.swift
+++ b/Sources/RedisProvider/RedisCache.swift
@@ -3,6 +3,7 @@ import Node
 import JSON
 import Core
 import Transport
+import class Sockets.TCPInternetSocket
 
 public struct RedisContext: Context {}
 
@@ -19,7 +20,7 @@ public final class RedisCache: CacheProtocol {
     /// Password should be nil if not required.
     public convenience init(hostname: String, port: Port, password: String? = nil, database: Int? = nil) throws {
         self.init {
-            let client = try Client(
+            let client: Client<TCPInternetSocket> = try Client(
                 hostname: hostname,
                 port: port,
                 password: password


### PR DESCRIPTION
The compiler is confused to which init to call(either the TLS one or the
regular TCP one).

Only use TCP for now, fixes compiler errors but not a permanent solution.