### PR TITLE
Fixed failing RedisCache when storing and retrieving Bytes

### DIFF
--- a/Sources/RedisProvider/RedisCache.swift
+++ b/Sources/RedisProvider/RedisCache.swift
@@ -67,6 +67,8 @@ public final class RedisCache: CacheProtocol {
         switch value.wrapped {
         case .string(let s):
             serialized = s.makeBytes()
+        case .bytes(let b):
+            serialized = b
         default:
             serialized = try JSON(value).serialize()
         }

--- a/Tests/RedisProviderTests/RedisCacheTests.swift
+++ b/Tests/RedisProviderTests/RedisCacheTests.swift
@@ -40,7 +40,7 @@ class RedisCacheTests: XCTestCase {
     func testBytes() throws {
         try cache.set("bytes", Node(bytes: [1, 2, 3]))
 
-        let bytes = try cache.get("bytes")?.bytes
+        let bytes: Bytes = try cache.get("bytes")?.bytes ?? []
 
         XCTAssertEqual(bytes, [1, 2, 3])
     }

--- a/Tests/RedisProviderTests/RedisCacheTests.swift
+++ b/Tests/RedisProviderTests/RedisCacheTests.swift
@@ -7,6 +7,7 @@ class RedisCacheTests: XCTestCase {
         ("testBasic", testBasic),
         ("testMissing", testMissing),
         ("testArray", testArray),
+        ("testBytes", testBytes),
         ("testObject", testObject),
         ("testDelete", testDelete),
         ("testExpire", testExpire)
@@ -34,6 +35,14 @@ class RedisCacheTests: XCTestCase {
         let value: Int = (array?[0].int) ?? 0
         
         XCTAssertEqual(value, 1)
+    }
+
+    func testBytes() throws {
+        try cache.set("bytes", Node(bytes: [1, 2, 3]))
+
+        let bytes = try cache.get("bytes")?.bytes
+
+        XCTAssertEqual(bytes, [1, 2, 3])
     }
     
     func testObject() throws {


### PR DESCRIPTION
The following used to fail (it would return different Bytes to the ones stored):

```swift
try cache.set("bytes", Node(bytes: [1, 2, 3]))
let bytes = try cache.get("bytes")?.bytes
XCTAssertEqual(bytes, [1, 2, 3]) // fail: [65, 81, 73, 68] is not equal
```

Now RedisCache handles Bytes properly without trying to serialise them into JSON. I have added the above test to the suite.